### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/esptool2.c
+++ b/esptool2.c
@@ -357,6 +357,11 @@ bool CreateBinFile(char *elffile, char *imagefile, int bootver, unsigned char mo
 		len = 0x10000 - ftell(outfile);
 		debug("Adding boot v1.1 padding, %d bytes of '0xff'.\r\n", len);
 		data = (unsigned char*)malloc(len);
+		if (!data) {
+			error("Error: Can't allocate memory.\r\n");
+			goto end_function;
+		}
+
 		memset(data, 0xff, len);
 		if(fwrite(data, 1, len, outfile) != len) {
 			error("Error: Failed to write boot v1.1 spacer.\r\n");


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The potential null pointer is passed into 'memset' function. Inspect the first argument. esptool2.c 360