### PR TITLE
esptool2.c: add mode 2048b.

### DIFF
--- a/esptool2.c
+++ b/esptool2.c
@@ -440,6 +440,8 @@ int main(int argc, char *argv[]) {
 			size = 2;
 		} else if (!strcmp(argv[i], "-2048")) {
 			size = 3;
+		} else if (!strcmp(argv[i], "-2048b")) {
+			size = 5;
 		} else if (!strcmp(argv[i], "-4096")) {
 			size = 4;
 		} else if (!strcmp(argv[i], "-20")) {


### PR DESCRIPTION
The default 2048 mode is defined as 512/512, mode 3. There is a newer
2048 mode which is defined as 1024/1024 and which I happen to use.

Prior to the SDK partition stuff (SDK 3), it was no problem to have 512/512
image and use it as 1024/1024, but now the SDK enforces the flash map
type.